### PR TITLE
Add support for AlertConfig

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -1,0 +1,38 @@
+package nightfall
+
+// AlertConfig allows clients to specify where alerts should be delivered when findings are discovered as
+// part of a scan. These alerts are delivered asynchronously to all destinations specified in the object instance.
+type AlertConfig struct {
+	Slack   *SlackAlert   `json:"slack"`
+	Email   *EmailAlert   `json:"email"`
+	Webhook *WebhookAlert `json:"url"`
+}
+
+// SlackAlert contains the configuration required to allow clients to send asynchronous alerts to a Slack
+// workspace when findings are detected.
+//
+// Note that in order for Slack alerts to be delivered to your workspace, you must use authenticate Nightfall
+// to your Slack workspace under the Settings menu on the Nightfall Dashboard.
+//
+// Currently, Nightfall supports delivering alerts to public channels, formatted like "#general".
+// Alerts are only sent if findings are detected.
+type SlackAlert struct {
+	Target string `json:"target"`
+}
+
+// EmailAlert contains the configuration required to allow clients to send an asynchronous email message
+// when findings are detected. The findings themselves will be delivered as a file attachment on the email.
+// Alerts are only sent if findings are detected.
+type EmailAlert struct {
+	Address string `json:"address"`
+}
+
+// WebhookAlert contains the configuration required to allow clients to send a webhook event to an external
+// URL when findings are detected. The URL provided must have a route defined on the HTTP POST method,
+// and should return a 200 status code upon receipt of the event.
+//
+// In contrast to other platforms, when using the file scanning APIs, an alert is also sent to this webhook
+// *even when there are no findings*.
+type WebhookAlert struct {
+	Address string `json:"address"`
+}

--- a/file.go
+++ b/file.go
@@ -12,16 +12,17 @@ import (
 	"github.com/google/uuid"
 )
 
-// An object containing configuration that describes how to scan a file. Since the file is scanned asynchronously,
+// ScanPolicy contains configuration that describes how to scan a file. Since the file is scanned asynchronously,
 // the results from the scan are delivered to the provided webhook URL. The scan configuration may contain both
 // inline detection rule definitions and UUID's referring to existing detection rules (up to 10 of each).
 type ScanPolicy struct {
-	WebhookURL         string          `json:"webhookURL"`
+	WebhookURL         string          `json:"webhookURL"` // Deprecated: use AlertConfig instead
 	DetectionRules     []DetectionRule `json:"detectionRules"`
 	DetectionRuleUUIDs []string        `json:"detectionRuleUUIDs"`
+	AlertConfig        *AlertConfig    `json:"alertConfig"`
 }
 
-// A container for a request to scan a file that was uploaded via the Nightfall API. Exactly one of
+// ScanFileRequest represents a request to scan a file that was uploaded via the Nightfall API. Exactly one of
 // PolicyUUID or Policy should be provided.
 type ScanFileRequest struct {
 	PolicyUUID       *string       `json:"policyUUID"`
@@ -32,7 +33,8 @@ type ScanFileRequest struct {
 	Timeout          time.Duration `json:"-"`
 }
 
-// The object returned by the Nightfall API when an (asynchronous) file scan request was successfully triggered.
+// ScanFileResponse is the object returned by the Nightfall API when an (asynchronous) file scan request
+// was successfully triggered.
 type ScanFileResponse struct {
 	ID      string `json:"id"`
 	Message string `json:"message"`
@@ -49,7 +51,7 @@ type fileUploadRequest struct {
 	FileSizeBytes int64 `json:"fileSizeBytes"`
 }
 
-// A convenience method that abstracts the details of the multi-step file upload and scan process.
+// ScanFile is a convenience method that abstracts the details of the multi-step file upload and scan process.
 // Calling this method for a given file is equivalent to (1) manually initializing a file upload session,
 // (2) uploading all chunks of the file, (3) completing the upload, and (4) triggering a scan of the file.
 //

--- a/text.go
+++ b/text.go
@@ -28,6 +28,7 @@ type Config struct {
 	DetectionRuleUUIDs     []string         `json:"detectionRuleUUIDs"`
 	ContextBytes           int              `json:"contextBytes"`
 	DefaultRedactionConfig *RedactionConfig `json:"defaultRedactionConfig"`
+	AlertConfig            *AlertConfig     `json:"alertConfig"`
 }
 
 // Finding represents an occurrence of a configured detector (i.e. finding) in the provided data.


### PR DESCRIPTION
Callers may provide an alertConfig object as part of either a synchronous plaintext scan, or an asynchronous file scan to fan alerts out to any of { slack, email, and webhook}.