### PR TITLE
Do not reuse http request on retry

### DIFF
--- a/nightfall_test.go
+++ b/nightfall_test.go
@@ -64,16 +64,16 @@ func TestDo(t *testing.T) {
 		t.Fatal("Error initializing client")
 	}
 
-	req, err := client.newRequest(http.MethodPost, s.URL, nil)
-	if err != nil {
-		t.Fatal("Error initializing request")
+	reqParams := requestParams{
+		method: http.MethodPost,
+		url:    s.URL,
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			callCount = 0
 			s.Config.Handler = test.handler
-			err = client.do(context.Background(), req, nil)
+			err = client.do(context.Background(), reqParams, nil)
 			if !test.wantErr && err != nil {
 				t.Errorf("Got unexpected error: %v", err)
 			}

--- a/text.go
+++ b/text.go
@@ -78,13 +78,19 @@ type Range struct {
 // correspond one-to-one with the input request payload list, so all findings stored in a given sub-list refer to
 // matches that occurred in the ith index of the request payload.
 func (c *Client) ScanText(ctx context.Context, request *ScanTextRequest) (*ScanTextResponse, error) {
-	req, err := c.newRequest(http.MethodPost, c.baseURL+"v3/scan", request)
+	body, err := encodeBodyAsJSON(request)
 	if err != nil {
 		return nil, err
 	}
+	reqParams := requestParams{
+		method:  http.MethodPost,
+		url:     c.baseURL + "v3/scan",
+		body:    body,
+		headers: c.defaultHeaders(),
+	}
 
 	scanResponse := &ScanTextResponse{}
-	err = c.do(ctx, req, scanResponse)
+	err = c.do(ctx, reqParams, scanResponse)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It's not safe to reuse a request with a body parameter, so refactor our retry handler to construct a new request on each retry attempt.

https://github.com/golang/go/issues/19653#issuecomment-341539160
https://go-review.googlesource.com/c/go/+/75671